### PR TITLE
Version 0.2, Add remote actions and authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,11 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 
+<<<<<<< 41ecea48e651b288464940cfb34d63eff56893fb
 
 **/.DS_Store
+=======
+**.DS_Store
+>>>>>>> WIP
 Packages
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,47 @@
+# Version 0.2
+
+Add remotes actions
+
+- Remotes
+  - List
+  - Get
+  - Pull
+  - Push
+  - Autheticate
+    - Password
+    - SSH key
+
+# Version 0.1
+
+Only the local actions are implemented.
+
+Available features:
+- RepositoryManager
+  - Open
+  - Init (bare)
+- Repository
+  - Branches
+    - Get
+    - Create
+    - Remove
+    - List
+  - Tags
+    - Get
+    - Create
+    - Remove
+    - List
+ - Index
+    - Add
+    - Remove
+    - Save
+    - Load
+    - Clear
+ - Head
+    - Analysis merge
+    - Merge
+    - Checkout (branch, tag, tree)
+    - Reset (soft, hard)
+ - Statues
+    - WorkingDirectoryClean
+    - List all
+ - Tree (only concept)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Swift binding for **libgit2** library
 
 At the moment, only some *libgit2* features are implemented. Merge requests are welcome.
 
-In version *0.1*, only the local actions are implemented.
-
 Available features:
 - RepositoryManager
   - Open
@@ -38,8 +36,23 @@ Available features:
     - List all
  - Tree (only concept)
 
+ - Remotes
+    - List
+    - Get
+    - Pull
+    - Push
+    - Autheticate
+        - Password
+        - SSH key
+
+
 # How to compile
 
-> Tested on MacOs Sierra with XCode 8 beta 4
+> Tested on MacOs Sierra with XCode 8 GM
 
 *libgit2* must be installed in `/usr/local` directory.
+
+# How to test credential
+
+Create JSON file containing credential information like ```Tests/Sample.json```  
+And set environnement variable ```AUTH_CONFIG_TEST_FILE``` with full path to JSON file.

--- a/Sources/Authentication.swift
+++ b/Sources/Authentication.swift
@@ -1,0 +1,83 @@
+//
+//  Authentication.swift
+//  Git2Swift
+//
+//  Created by Damien Giron on 20/08/2016.
+//  Copyright © 2016 Creabox. All rights reserved.
+//
+
+import Foundation
+
+import CLibgit2
+
+/// Wrapp authentication to C function
+internal class AuthenticationWrapper<T> {
+    
+    /// Object
+    let object: T
+    
+    /// Init wrapper
+    ///
+    /// - parameter object: Wrapper
+    ///
+    /// - returns: Wrapper
+    init(_ object: T) {
+        self.object = object
+    }
+}
+
+/// Authentication handler
+public protocol AuthenticationHandler {
+    
+    /// Raw libgit2 authentication
+    ///
+    /// - parameter out:      Git credential
+    /// - parameter url:      url
+    /// - parameter username: username
+    ///
+    /// - returns: 0 on ok
+    func authenticate(out: UnsafeMutablePointer<UnsafeMutablePointer<git_cred>?>?,
+                      url: String?,
+                      username: String?) -> Int32
+}
+
+
+
+func setAuthenticationCallback(_ callbacksStruct: inout git_remote_callbacks,
+                               authentication: AuthenticationHandler?) {
+    
+    // Convert handler to payload pointer
+    callbacksStruct.payload = Unmanaged
+        .passRetained(AuthenticationWrapper(authentication))
+        .toOpaque()
+    
+    // Create crdential lambda calling credential handler
+    callbacksStruct.credentials = { out, url, username_from_url, allowed_types, payload in
+        
+        // Find url
+        let sUrl : String?
+        if (url == nil) {
+            sUrl = nil
+        } else {
+            sUrl = git_string_converter(url!)
+        }
+        
+        // Find username_from_url
+        let userName : String?
+        if (username_from_url == nil) {
+            userName = nil
+        } else {
+            userName = git_string_converter(username_from_url!)
+        }
+        
+        // Transformation du pointer en wrapper
+        let authenticationWrapper = Unmanaged<AuthenticationWrapper<AuthenticationHandler>>
+            .fromOpaque(payload!)
+            .takeRetainedValue()
+        let result = authenticationWrapper.object.authenticate(out: out,
+                                                               url: sUrl,
+                                                               username: userName)
+        
+        return result
+    }
+}

--- a/Sources/Branch.swift
+++ b/Sources/Branch.swift
@@ -27,11 +27,14 @@ public enum BranchType : UInt32 {
 /// - returns: libgit2 branch
 func git_convert_branch_type(_ type: BranchType) -> git_branch_t {
     
-    if (type == .remote) {
+    switch type {
+    case .local:
+        return GIT_BRANCH_LOCAL
+    case .remote:
         return GIT_BRANCH_REMOTE
+    case .all:
+        return GIT_BRANCH_ALL
     }
-    
-    return GIT_BRANCH_LOCAL
 }
 
 /// Convert a libgit2 branch to Git2Swift branch.
@@ -55,6 +58,37 @@ public class Branch : Reference {
     
     /// Type of branch
     public let type: BranchType
+    
+    lazy public var shortName : String = {
+        do {
+            return try Branch.getSpecInfo(spec: self.name, type: self.type).name
+        } catch {
+            return self.name
+        }
+    } ()
+    
+    /// Decode rbanch spec in name and type
+    ///
+    /// - parameter spec: Full spec
+    /// - parameter type: Known type for optimisation (may be null)
+    ///
+    /// - throws: GitError
+    ///
+    /// - returns: Typle (name, type)
+    public static func getSpecInfo(spec: String, type: BranchType? = nil) throws -> (name: String, type: BranchType) {
+        
+        // Test local
+        if ((type != nil && type! == .local) || spec.hasPrefix("refs/heads/")) {
+            let name = spec.substring(from: spec.index(spec.startIndex, offsetBy: 11))
+            return (name, BranchType.local)
+            // Test remote
+        } else if ((type != nil && type! == .remote) || spec.hasPrefix("refs/remotes/")) {
+            let name = spec.substring(from: spec.index(spec.startIndex, offsetBy: 13))
+            return (name, BranchType.local)
+        } else {
+            throw GitError.invalidSpec(spec: spec)
+        }
+    }
     
     /// Constructor with repository, name and libgit2 pointer
     ///

--- a/Sources/Branches.swift
+++ b/Sources/Branches.swift
@@ -20,8 +20,33 @@ public class Branches {
     /// - parameter repository: Git2Swift repository
     ///
     /// - returns: Branches
-    init(withRepository repository: Repository) {
+    init(repository: Repository) {
         self.repository = repository
+    }
+    
+    /// All branch names
+    public func names(type: BranchType = .local) throws -> [String] {
+        
+        var strs = [String]()
+        
+        for branch in try all(type: type) {
+            strs.append(branch.name)
+        }
+        
+        
+        return strs
+    }
+    
+    /// Get branch with full reference name
+    ///
+    /// - parameter name: Branch name
+    ///
+    /// - throws: GitError (notFound, invalidSpec)
+    ///
+    /// - returns: Branch
+    public func get(spec: String) throws -> Branch {
+        let specInfo = try Branch.getSpecInfo(spec: spec)
+        return try get(name: specInfo.name, type: specInfo.type)
     }
     
     /// Get branch by name

--- a/Sources/BranchesIterator.swift
+++ b/Sources/BranchesIterator.swift
@@ -59,7 +59,7 @@ public class BranchIterator : Sequence, IteratorProtocol {
         }
         
         // find next
-        let result : Int32 = git_branch_next(branch, type, branch_iterator.pointee)
+        let result = git_branch_next(branch, type, branch_iterator.pointee)
         
         // Test next
         if (result != GIT_ITEROVER.rawValue) {

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/KeyAuthentication.swift
+++ b/Sources/KeyAuthentication.swift
@@ -1,0 +1,108 @@
+//
+//  KeyAuthentication.swift
+//  Git2Swift
+//
+//  Created by Damien Giron on 11/09/2016.
+//  Copyright © 2016 Creabox. All rights reserved.
+//
+
+import Foundation
+
+import CLibgit2
+
+public protocol SshKeyData {
+    
+    /// Find user name
+    var username : String? {
+        get
+    }
+    
+    /// Find public key URL
+    var publicKey : URL {
+        get
+    }
+    
+    /// Find private key URL
+    var privateKey : URL {
+        get
+    }
+    
+    /// Key pass phrase (may be nil)
+    var passphrase : String? {
+        get
+    }
+}
+
+public struct RawSshKeyData : SshKeyData {
+    public let username : String?
+    public let publicKey : URL
+    public let privateKey : URL
+    public let passphrase : String?
+    
+    public init(username : String?, publicKey : URL, privateKey : URL, passphrase : String? = nil) {
+        self.username = username
+        self.publicKey = publicKey
+        self.privateKey = privateKey
+        self.passphrase = passphrase
+    }
+}
+
+/// Ssh key delegate
+public protocol SshKeyDelegate {
+    
+    /// Get ssh key data
+    ///
+    /// - parameter username: username
+    /// - parameter url:      url
+    ///
+    /// - returns: Password data
+    func get(username: String?, url: URL?) -> SshKeyData
+}
+
+/// SSh authentication
+public class SshKeyHandler : AuthenticationHandler {
+    
+    /// Delegate to access SSH key
+    private let sshKeyDelegate: SshKeyDelegate
+    
+    public init(sshKeyDelegate: SshKeyDelegate) {
+        self.sshKeyDelegate = sshKeyDelegate
+    }
+    
+    /// Authentication
+    ///
+    /// - parameter out:      Git credential
+    /// - parameter url:      url
+    /// - parameter username: username
+    ///
+    /// - returns: 0 on ok
+    public func authenticate(out: UnsafeMutablePointer<UnsafeMutablePointer<git_cred>?>?,
+                             url: String?,
+                             username: String?) -> Int32 {
+        
+        // Find ssh key data
+        let sshKeyData = sshKeyDelegate.get(username: username, url: url == nil ? nil : URL(string: url!))
+        
+        // Public key
+        let publicKey = sshKeyData.publicKey.path
+        if (FileManager.default.fileExists(atPath: publicKey) == false) {
+            return 1
+        }
+        
+        // Private key
+        let privateKey = sshKeyData.privateKey.path
+        if (FileManager.default.fileExists(atPath: privateKey) == false) {
+            return 2
+        }
+        
+        // User name
+        let optionalUsername = sshKeyData.username
+        let optionalPassPhrase = sshKeyData.passphrase
+        
+        return git_cred_ssh_key_new(out,
+                                    optionalUsername == nil ? "": optionalUsername!,
+                                    publicKey,
+                                    privateKey,
+                                    optionalPassPhrase == nil ? "": optionalPassPhrase!)
+    }
+}

--- a/Sources/PasswordAuthentication.swift
+++ b/Sources/PasswordAuthentication.swift
@@ -1,0 +1,77 @@
+//
+//  PasswordAuthentication.swift
+//  Git2Swift
+//
+//  Created by Damien Giron on 11/09/2016.
+//  Copyright © 2016 Creabox. All rights reserved.
+//
+
+import Foundation
+
+import CLibgit2
+
+public protocol PasswordData {
+    var username : String? {
+        get
+    }
+    var password : String? {
+        get
+    }
+}
+
+public struct RawPasswordData : PasswordData {
+    public let username : String?
+    public let password : String?
+    
+    public init(username : String?, password : String?) {
+        self.username = username
+        self.password = password
+    }
+}
+
+/// Password delegate
+public protocol PasswordDelegate {
+    
+    /// Get password data
+    ///
+    /// - parameter username: username
+    /// - parameter url:      url
+    ///
+    /// - returns: Password data
+    func get(username: String?, url: URL?) -> PasswordData
+}
+
+/// Password handler
+public class PasswordHandler : AuthenticationHandler {
+    
+    /// Password delegate
+    private let passwordDelegate : PasswordDelegate
+    
+    public init(passwordDelegate: PasswordDelegate) {
+        self.passwordDelegate = passwordDelegate
+    }
+    
+    /// Authentication
+    ///
+    /// - parameter out:      Git credential
+    /// - parameter url:      url
+    /// - parameter username: user name
+    ///
+    /// - returns: 0 on ok
+    public func authenticate(out: UnsafeMutablePointer<UnsafeMutablePointer<git_cred>?>?,
+                             url: String?,
+                             username: String?) -> Int32 {
+        
+        // Find password data
+        let passwordData = passwordDelegate.get(username: username, url: url == nil ? nil : URL(string: url!))
+        
+        let optionalUsername = passwordData.username
+        let optionalPasword = passwordData.password
+        
+        // Auth plain text
+        return git_cred_userpass_plaintext_new(
+            out,
+            optionalUsername == nil ? "" : optionalUsername!,
+            optionalPasword == nil ? "" : optionalPasword!)
+    }
+}

--- a/Sources/Reference.swift
+++ b/Sources/Reference.swift
@@ -73,13 +73,6 @@ public class Reference {
     /// Libgit2 refrence pointer
     internal let pointer : UnsafeMutablePointer<OpaquePointer?>
     
-    ///
-    /// Target reference.
-    /// - Returns reference
-    /// - Throws GitError
-    ///
-    
-    
     /// Target reference
     ///
     /// - throws: GitError

--- a/Sources/Remote.swift
+++ b/Sources/Remote.swift
@@ -1,0 +1,133 @@
+//
+//  Remote.swift
+//  Git2Swift
+//
+//  Created by Damien Giron on 17/08/2016.
+//  Copyright © 2016 Creabox. All rights reserved.
+//
+
+import Foundation
+
+import CLibgit2
+
+/// Define remote repository.
+public class Remote {
+    
+    /// Repository
+    let repository : Repository
+    
+    /// Remote name
+    public let name: String
+    
+    /// Remote pointer
+    internal let pointer: UnsafeMutablePointer<OpaquePointer?>
+    
+    /// Constructor with repository, pointer and name
+    ///
+    /// - parameter repository: repository
+    /// - parameter pointer:    pointer
+    /// - parameter name:       name
+    ///
+    /// - returns: Remote
+    init(repository: Repository, pointer: UnsafeMutablePointer<OpaquePointer?>, name: String) {
+        self.repository = repository
+        self.name = name
+        self.pointer = pointer
+    }
+    
+    
+    /// Fetch all remote branches
+    /// - parameter authentication: Authentication callback, maybe nil
+    ///
+    /// - throws: GitError
+    public func fetch(authentication: AuthenticationHandler? = nil) throws {
+        
+        // Define fetch options
+        var fetchOptions = git_fetch_options()
+        fetchOptions.version = 1
+        fetchOptions.callbacks.version = 1
+        fetchOptions.prune = GIT_FETCH_PRUNE_UNSPECIFIED
+        fetchOptions.update_fetchhead = 1
+        
+        // test authentication
+        if (authentication != nil) {
+            setAuthenticationCallback(&fetchOptions.callbacks, authentication: authentication)
+        }
+        
+        // Fetch remote
+        let error = git_remote_fetch(pointer.pointee, nil, &fetchOptions, nil)
+        if (error != 0) {
+            throw gitUnknownError("Unable to fetch from remote", code: error)
+        }
+    }
+    
+    /// Pull all remote branches
+    ///
+    /// - parameter signature: Signature
+    /// - parameter remote: Remote branch to merge
+    /// - parameter authentication: Authentication callback, maybe nil
+    ///
+    /// - throws: GitError
+    public func pull(signature: Signature, remote: Branch? = nil,
+                     authentication: AuthenticationHandler? = nil) throws -> Bool {
+        
+        // Fetch remote
+        try fetch(authentication: authentication)
+        
+        let remoteBranch: Branch
+        
+        if (remote == nil) {
+            
+            // Find spec informations
+            let specInfo = try Branch.getSpecInfo(spec: repository.head().targetReference().name)
+            
+            // Find remote branch
+            remoteBranch = try repository.branches.get(name: "\(name)/\(specInfo.name)", type: .remote)
+        } else {
+            remoteBranch = remote!
+        }
+        
+        // Merge head
+        return try repository.head().merge(branch: remoteBranch, signature: signature)
+    }
+    
+    /// Push a branch to remote
+    ///
+    /// - parameter local:  Local branch
+    /// - parameter remote: Remote branch or nil for same remote branch
+    /// - parameter authentication: Authentication callback, maybe nil
+    ///
+    /// - throws: GitError
+    public func push(local: Branch, remote: Branch? = nil,
+                     authentication: AuthenticationHandler? = nil) throws {
+   
+        // Set options
+        var opts = git_push_options()
+        opts.version = 1
+        opts.callbacks.version = 1
+        
+        // test authentication
+        if (authentication != nil) {
+            setAuthenticationCallback(&opts.callbacks, authentication: authentication)
+        }
+        
+        // Create refspec
+        let refspec : String
+        if (remote == nil) {
+            refspec = "\(local.name):\(local.name)"
+        } else {
+            refspec = "\(local.name):refs/heads/\(remote!.shortName)"
+        }
+        
+        // Create refspecs
+        let wrapper = StringWrapper(withStrs: [refspec])
+        
+        // Create str array
+        var refspecs = git_strarray(strings: wrapper.pointer, count:  wrapper.count)
+
+        let error = git_remote_push(pointer.pointee, &refspecs, &opts);
+        if (error != 0) {
+            throw gitUnknownError("Unable to push to remote", code: error)
+        }
+    }
+}

--- a/Sources/Remotes.swift
+++ b/Sources/Remotes.swift
@@ -1,0 +1,126 @@
+//
+//  Remotes.swift
+//  Git2Swift
+//
+//  Created by Damien Giron on 17/08/2016.
+//  Copyright © 2016 Creabox. All rights reserved.
+//
+
+import Foundation
+
+import CLibgit2
+
+/// Manage remote repository
+public class Remotes {
+    
+    /// Repository
+    private let repository : Repository
+    
+    /// Constructor with repository manager
+    ///
+    /// - parameter repository: Repository
+    ///
+    /// - returns: Remotes
+    init(repository: Repository) {
+        self.repository = repository
+    }
+    
+    /// Find remote names
+    ///
+    /// - throws: GitError
+    ///
+    /// - returns: String array
+    public func remoteNames() throws -> [String] {
+        
+        // Store remote names
+        var remotes = git_strarray()
+        
+        // List remotes
+        let error = git_remote_list(&remotes, repository.pointer.pointee)
+        if (error != 0) {
+            throw gitUnknownError("Unable to list remotes", code: error)
+        }
+        
+        return git_strarray_to_strings(&remotes)
+    }
+    
+    /// Find remote by name.
+    ///
+    /// - parameter name: Remote name
+    ///
+    /// - throws: GitError
+    ///
+    /// - returns: Remote
+    public func get(name: String) throws -> Remote {
+        
+        // Remote pointer
+        let remote = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
+        
+        // Lookup remote
+        let error = git_remote_lookup(remote, repository.pointer.pointee, name)
+        if (error != 0) {
+            
+            remote.deinitialize()
+            remote.deallocate(capacity: 1)
+            
+            switch(error) {
+            case GIT_ENOTFOUND.rawValue:
+                throw GitError.notFound(ref: name)
+            case GIT_EINVALIDSPEC.rawValue:
+                throw GitError.invalidSpec(spec: name)
+            default:
+                throw gitUnknownError("Unable to lookup remote \(name)", code: error)
+            }
+        }
+        
+        return Remote(repository: repository, pointer: remote, name: name)
+    }
+    
+    
+    /// Create remote
+    ///
+    /// - parameter name: Remote name
+    /// - parameter url:  URL
+    ///
+    /// - throws: GitError
+    ///
+    /// - returns: Remote
+    public func create(name: String, url: URL) throws -> Remote {
+        
+        // Remote pointer
+        let remote = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
+        
+        // Create remote
+        let error = git_remote_create(remote, repository.pointer.pointee,
+                                      name, url.path)
+        if (error != 0) {
+            switch(error) {
+            case GIT_EINVALIDSPEC.rawValue:
+                throw GitError.invalidSpec(spec: name)
+            case GIT_EEXISTS.rawValue:
+                throw GitError.alreadyExists(ref: name)
+            default:
+                throw gitUnknownError("Unable to create remote \(name)",
+                    code: error)
+            }
+        }
+        
+        return Remote(repository: repository, pointer: remote, name: name)
+    }
+    
+    
+    /// Remove remote
+    ///
+    /// - parameter name: Remote name
+    ///
+    /// - throws: GitError
+    public func remove(name: String) throws {
+        
+        // remove remote
+        let error = git_remote_delete(repository.pointer.pointee, name)
+        if (error != 0) {
+            throw gitUnknownError("Unable to remove remote \(name)",
+                code: error)
+        }
+    }
+}

--- a/Sources/Repository.swift
+++ b/Sources/Repository.swift
@@ -23,7 +23,7 @@ public class Repository {
     
     /// Branches manager
     lazy public private(set) var branches : Branches = {
-        Branches(withRepository: self)
+        Branches(repository: self)
     } ()
     
     /// Statuses manager
@@ -34,6 +34,10 @@ public class Repository {
     /// Access tags manager
     lazy public private(set) var tags : Tags = {
         Tags(repository: self)
+    } ()
+    
+    lazy public private(set) var remotes : Remotes = {
+        Remotes(repository: self)
     } ()
     
     /// Constructor with repository manager and libgit2 repository

--- a/Sources/RepositoryManager.swift
+++ b/Sources/RepositoryManager.swift
@@ -100,6 +100,23 @@ public class RepositoryManager {
         // Open repository
         return try Repository(openAt: url, manager: self)
     }
+    
+    /// Clone repository
+    ///
+    /// - parameter remoteUrl: Remote URL
+    /// - parameter url:       Repository URL
+    /// - parameter authentication: Authentication handler
+    ///
+    /// - throws: GitError wrapping libgit2 error
+    ///
+    /// - returns: Repository
+    public func cloneRepository(from remoteUrl: URL,
+                                at url: URL,
+                                authentication: AuthenticationHandler? = nil) throws -> Repository {
+        
+        // Open repository
+        return try Repository(cloneFrom: remoteUrl, at: url, manager: self, authentication: authentication)
+    }
 
     /// Find system signature
     ///

--- a/Sources/Strings.swift
+++ b/Sources/Strings.swift
@@ -26,9 +26,78 @@ func git_string_converter(_ cStr: UnsafePointer<CChar>) -> String {
 func git_strarray_to_strings(_ strarray: inout git_strarray) -> [String] {
     
     var strs = [String]()
-    strs.reserveCapacity(strarray.count)
-    for i in 0...(strarray.count - 1) {
+    
+    let count = strarray.count
+    if (count == 0) {
+        return strs
+    }
+    
+    strs.reserveCapacity(count)
+    for i in 0...(count - 1) {
         strs.append(String(cString: strarray.strings[i]!))
     }
     return strs
+}
+
+
+///
+/// Define a string wrapper used to transform a String array to pointer array.
+///
+class StringWrapper {
+    
+    ///
+    /// Raw UTF-8
+    ///
+    private var rawUtf8 = [ContiguousArray<Int8>]()
+    
+    ///
+    /// Character count.
+    ///
+    let count : Int
+    
+    ///
+    /// Pointer to 'const char **'
+    ///
+    private(set) var pointer : UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>
+    
+    ///
+    /// Init string wrapper.
+    /// - Parameter strs : String array.
+    ///
+    init(withStrs strs: [String]) {
+        
+        // String count
+        count = strs.count
+        
+        // Create result
+        pointer = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: count)
+        
+        // Store raw utf8
+        rawUtf8.reserveCapacity(count)
+        
+        // Init iterator
+        var iterator = pointer
+        
+        // Iterate other strings
+        for str in strs {
+            
+            // Create utf8 cString
+            let cStr : ContiguousArray<Int8> = str.utf8CString
+            rawUtf8.append(cStr)
+            
+            // Set pointer
+            let cStr1 = cStr.withUnsafeBufferPointer { UnsafeMutablePointer<Int8>(mutating: $0.baseAddress) }
+            
+            // Initialize with utf8 data
+            iterator.initialize(to: cStr1)
+            
+            // Add successor
+            iterator = iterator.successor()
+        }
+    }
+    
+    deinit {
+        pointer.deinitialize()
+        pointer.deallocate(capacity: count)
+    }
 }

--- a/Sources/Tags.swift
+++ b/Sources/Tags.swift
@@ -51,12 +51,22 @@ public class Tags {
     /// - returns: Tag
     public func get(name: String) throws -> Tag {
         
+        let spec : String
+        let shortName : String
+        
+        // Find spec
+        if (name.hasPrefix("refs/tags/")) {
+            spec = name
+            shortName = name.substring(from: name.index(name.startIndex, offsetBy: 10))
+        } else {
+            spec = "refs/tags/\(name)"
+            shortName = name
+        }
+        
         let reference = UnsafeMutablePointer<OpaquePointer?>.allocate(capacity: 1)
         
-        // TODO Find full path
-        
         // Find tag reference
-        let error = git_reference_lookup(reference, repository.pointer.pointee, "refs/tags/\(name)")
+        let error = git_reference_lookup(reference, repository.pointer.pointee, spec)
         if (error != 0) {
             
             // 0 on success, GIT_ENOTFOUND, GIT_EINVALIDSPEC or an error code.
@@ -77,7 +87,7 @@ public class Tags {
             throw GitError.notFound(ref: "refs/tags/\(name)")
         }
         
-        return Tag(repository: repository, name: name, oid: OID(withGitOid: gOid!.pointee))
+        return Tag(repository: repository, name: shortName, oid: OID(withGitOid: gOid!.pointee))
     }
     
     

--- a/Tests/Git2SwiftTests/AuthenticationTest.swift
+++ b/Tests/Git2SwiftTests/AuthenticationTest.swift
@@ -1,0 +1,187 @@
+//
+//  AuthenticationTest.swift
+//  Git2Swift
+//
+//  Created by Damien Giron on 20/08/2016.
+//  Copyright © 2016 Creabox. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+
+@testable import Git2Swift
+
+// --- Delegates ---
+
+class StaticPasswordDelegate : PasswordDelegate {
+    
+    let passwordStr : String
+    
+    init(password: String) {
+        self.passwordStr = password
+    }
+    
+    public func get(username: String?, url: URL?) -> PasswordData {
+        return RawPasswordData(username: username, password: passwordStr)
+    }
+}
+
+
+class StaticSshKeyDelegate : SshKeyDelegate {
+    
+    let publicUrl: URL
+    let privateUrl: URL
+    
+    init(publicUrl: URL, privateUrl: URL) {
+        self.publicUrl = publicUrl
+        self.privateUrl = privateUrl
+    }
+    
+    public func get(username: String?, url: URL?) -> SshKeyData {
+        return RawSshKeyData(username: username, publicKey: publicUrl, privateKey: privateUrl)
+    }
+}
+
+// --- Config ---
+
+class AuthenticationInfo {
+    
+    let authenticationTest : Bool
+    let user : String
+    let password : String
+    let privateKeyFile : String
+    let publicKeyFile : String
+    
+    static func readString(dictionnary: Dictionary<String, AnyObject>?,
+                           key: String,
+                           defaultValue: AnyObject) -> AnyObject {
+        
+        guard dictionnary != nil else {
+            return defaultValue
+        }
+        
+        // Find key
+        let configObject = dictionnary![key]
+        if (configObject == nil) {
+            return defaultValue
+        } else {
+            return configObject!
+        }
+        
+    }
+    
+    init(dictionnary: Dictionary<String, AnyObject>?) {
+        
+        authenticationTest = AuthenticationInfo.readString(dictionnary: dictionnary,
+                                            key:"authenticationTest",
+                                            defaultValue: false as AnyObject) as! Bool
+        user = AuthenticationInfo.readString(dictionnary: dictionnary,
+                                            key:"login",
+                                            defaultValue: "" as AnyObject) as! String
+        password = AuthenticationInfo.readString(dictionnary: dictionnary,
+                                            key:"password",
+                                            defaultValue: "" as AnyObject) as! String
+        privateKeyFile = AuthenticationInfo.readString(dictionnary: dictionnary,
+                                            key:"privateKey",
+                                            defaultValue: "" as AnyObject) as! String
+        publicKeyFile = AuthenticationInfo.readString(dictionnary: dictionnary,
+                                            key:"publicKey",
+                                            defaultValue: "" as AnyObject) as! String
+    }
+    
+    convenience init(data: Data?) {
+        
+        var dictionnary : Dictionary<String, AnyObject>?
+        
+        do {
+            dictionnary = try JSONSerialization.jsonObject(with: data!, options: []) as? Dictionary<String, AnyObject>
+        } catch {
+            print(error)
+        }
+        
+        self.init(dictionnary: dictionnary)
+    }
+}
+
+class AuthenticationTest: XCTestCase {
+    
+    static let name = "repoAuthentication"
+    
+    func testCloneRepository() throws {
+        
+        // Process Info
+        let dict = ProcessInfo.processInfo.environment
+        
+        // Find config file 
+        let configFile = dict["AUTH_CONFIG_TEST_FILE"]
+        if (configFile == nil) {
+            NSLog("Auth test disabled : No config file")
+            return
+        }
+        
+        let authenticationInfo = AuthenticationInfo(data: FileManager.default.contents(atPath: configFile!))
+        
+        guard authenticationInfo.authenticationTest else {
+            NSLog("Authentication not set, so not tested");
+            return
+        }
+        
+        let user = authenticationInfo.user
+        
+        do {
+            
+            let basePath = try DirectoryManager.initDirectory(name: AuthenticationTest.name + "Base")
+            
+            let repositoryManager = RepositoryManager()
+            
+            // base repository
+            let baseRepository = try repositoryManager.initRepository(at: basePath,
+                                                                      signature: repositoryManager.systemSignature(), bare: true)
+            
+            let cloneUrl = URL(string: "ssh://\(user)@localhost\(baseRepository.url.path)")
+            guard cloneUrl != nil else {
+                throw GitError.notFound(ref: "URL not found :-(")
+            }
+            
+            // Create repository at URL
+            let clonedPasswordPath = try DirectoryManager.initDirectory(name: RepositoryTest.name + "PasswordClone")
+            
+            // Create repo
+            let repository1 = try repositoryManager.cloneRepository(from: cloneUrl!,
+                                                                    at: clonedPasswordPath,
+                                                                    authentication: PasswordHandler(
+                                                                        passwordDelegate: StaticPasswordDelegate(password: authenticationInfo.password)))
+            
+            XCTAssertEqual("Initial commit", try repository1.head().targetCommit().summary)
+            
+            // Create repository at URL
+            let clonedKeyPath = try DirectoryManager.initDirectory(name: RepositoryTest.name + "KeyClone")
+            
+            
+            // Public key
+            let publickeyUrl = URL(string: authenticationInfo.publicKeyFile)
+            let privatekeyUrl = URL(string: authenticationInfo.privateKeyFile)
+            
+            if (publickeyUrl == nil || privatekeyUrl == nil) {
+                XCTFail("No ssh key")
+            } else {
+                
+                let sshKeyDelegate = StaticSshKeyDelegate(publicUrl:publickeyUrl!,
+                                                          privateUrl:privatekeyUrl!)
+                
+                // Create repo
+                let repository2 = try repositoryManager.cloneRepository(from: cloneUrl!,
+                                                                        at: clonedKeyPath,
+                                                                        authentication: SshKeyHandler(
+                                                                            sshKeyDelegate: sshKeyDelegate))
+                
+                XCTAssertEqual("Initial commit", try repository2.head().targetCommit().summary)
+            }
+            
+        } catch  {
+            XCTFail("\(error)")
+        }
+    }
+}
+

--- a/Tests/Git2SwiftTests/BranchTest.swift
+++ b/Tests/Git2SwiftTests/BranchTest.swift
@@ -27,10 +27,16 @@ class BranchTest: XCTestCase {
             // Find master
             let masterBranch = try branches.get(name: "master")
             
+            // Find master
+            let fullNameMasterBranch = try branches.get(spec: "refs/heads/master")
+            
+            XCTAssertEqual(masterBranch.name, fullNameMasterBranch.name)
+            
             // Find invalid branch
             XCTAssertThrowsError(try branches.get(name: "branch"))
             
             XCTAssertEqual("refs/heads/master", masterBranch.name)
+            XCTAssertEqual("master", masterBranch.shortName)
             XCTAssertEqual(BranchType.local, masterBranch.type)
             
             // Add file 1

--- a/Tests/Git2SwiftTests/DirectoryManager.swift
+++ b/Tests/Git2SwiftTests/DirectoryManager.swift
@@ -23,6 +23,10 @@ class DirectoryManager {
     ///
     private static func initBase() throws -> URL {
         
+        if (true) {
+            return baseBase
+        }
+        
         if (temporaryDirectory == nil) {
             temporaryDirectory = NSTemporaryDirectory().appending(NSUUID().uuidString)
             

--- a/Tests/Git2SwiftTests/RemoteTest.swift
+++ b/Tests/Git2SwiftTests/RemoteTest.swift
@@ -1,0 +1,195 @@
+//
+//  RemoteTest.swift
+//  Git2Swift
+//
+//  Created by Damien Giron on 17/08/2016.
+//  Copyright © 2016 Creabox. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+
+@testable import Git2Swift
+
+class RemoteTest: XCTestCase {
+    
+    static let name = "remoteRepo"
+    
+    func testRemoteRepository() {
+        
+        do {
+            
+            // base repository
+            let baseRepository = try RepositoryHelper.createRepository(name: RemoteTest.name + "Remotes")
+            
+            // List remotes
+            XCTAssertEqual(0, try baseRepository.remotes.remoteNames().count)
+            
+            // Create remote
+            _ = try baseRepository.remotes.create(name: "remote1",
+                                                  url: URL(string: "http://localhost/tmp/")!)
+            
+            // List remotes
+            XCTAssertEqual(1, try baseRepository.remotes.remoteNames().count)
+            XCTAssertEqual("remote1", try baseRepository.remotes.remoteNames()[0])
+            
+            // Remove
+            try baseRepository.remotes.remove(name: "remote1")
+            XCTAssertEqual(0, try baseRepository.remotes.remoteNames().count)
+            
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testFetchRepository() {
+        
+        do {
+            
+            let repositoryManager = RepositoryManager()
+            
+            // base repository
+            let baseRepository = try RepositoryHelper.createRepository(name: RemoteTest.name + "FetchBase")
+            
+            // Add file 1
+            _ = try RepositoryHelper.addFile(repository: baseRepository, name: "file1")
+            
+            var baseNames = try baseRepository.branches.names()
+            XCTAssertEqual(1, baseNames.count)
+            XCTAssertEqual("refs/heads/master", baseNames[0])
+            
+            // Create repository at URL
+            let clonedPath = try DirectoryManager.initDirectory(name: RemoteTest.name + "FetchClone")
+            
+            // Clone repo
+            let cloneRepository = try repositoryManager.cloneRepository(from: baseRepository.url, at: clonedPath)
+            
+            var remoteNames = try cloneRepository.branches.names(type: BranchType.all)
+            XCTAssertEqual(2, remoteNames.count)
+            XCTAssertEqual("refs/heads/master", remoteNames[0])
+            XCTAssertEqual("refs/remotes/origin/master", remoteNames[1])
+            
+            // Create new branch on base
+            _ = try baseRepository.branches.create(name: "branch1")
+            
+            baseNames = try baseRepository.branches.names()
+            XCTAssertEqual(2, baseNames.count)
+            XCTAssertEqual("refs/heads/branch1", baseNames[0])
+            XCTAssertEqual("refs/heads/master", baseNames[1])
+            
+            // Fetch new branches
+            try cloneRepository.remotes.get(name: "origin").fetch()
+            
+            remoteNames = try cloneRepository.branches.names(type: BranchType.all)
+            XCTAssertEqual(3, remoteNames.count)
+            XCTAssertEqual("refs/heads/master", remoteNames[0])
+            XCTAssertEqual("refs/remotes/origin/branch1", remoteNames[1])
+            XCTAssertEqual("refs/remotes/origin/master", remoteNames[2])
+            
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    
+    func testPushRepository() {
+        
+        do {
+            
+            let repositoryManager = RepositoryManager()
+            
+            let basePath = try DirectoryManager.initDirectory(name: RemoteTest.name + "PullBase")
+            
+            // base repository
+            let baseRepository = try repositoryManager.initRepository(at: basePath,
+                                                                      signature: repositoryManager.systemSignature(), bare: true)
+            
+            var baseNames = try baseRepository.branches.names()
+            XCTAssertEqual(1, baseNames.count)
+            XCTAssertEqual("refs/heads/master", baseNames[0])
+            
+            // Create repository at URL
+            let clonedPath = try DirectoryManager.initDirectory(name: RemoteTest.name + "PullClone")
+            
+            // Clone repo
+            let cloneRepository = try repositoryManager.cloneRepository(from: baseRepository.url, at: clonedPath)
+            
+            var remoteNames = try cloneRepository.branches.names(type: BranchType.all)
+            XCTAssertEqual(2, remoteNames.count)
+            XCTAssertEqual("refs/heads/master", remoteNames[0])
+            XCTAssertEqual("refs/remotes/origin/master", remoteNames[1])
+            
+            // Create new branch on base
+            _ = try cloneRepository.branches.create(name: "branch1")
+            
+            remoteNames = try cloneRepository.branches.names()
+            XCTAssertEqual(2, remoteNames.count)
+            XCTAssertEqual("refs/heads/branch1", remoteNames[0])
+            XCTAssertEqual("refs/heads/master", remoteNames[1])
+            
+            // Fetch new branches
+            try cloneRepository.remotes.get(name: "origin").push(local: cloneRepository.branches.get(name: "branch1"))
+            
+            baseNames = try baseRepository.branches.names(type: BranchType.all)
+            XCTAssertEqual(2, baseNames.count)
+            XCTAssertEqual("refs/heads/branch1", baseNames[0])
+            XCTAssertEqual("refs/heads/master", baseNames[1])
+            
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+    
+    func testPullRepository() {
+        
+        do {
+            
+            let repositoryManager = RepositoryManager()
+            
+            // base repository
+            let baseRepository = try RepositoryHelper.createRepository(name: RemoteTest.name + "PullBase")
+            
+            // Create repository at URL
+            let clonedPath = try DirectoryManager.initDirectory(name: RemoteTest.name + "PullClone")
+            
+            // Add file 1
+            let url1 = try RepositoryHelper.addFile(repository: baseRepository, name: "file1")
+            let url1b = clonedPath.appendingPathComponent(url1.lastPathComponent)
+            
+            XCTAssertTrue(FileManager.default.fileExists(atPath: url1.path))
+            XCTAssertFalse(FileManager.default.fileExists(atPath: url1b.path))
+            
+            // Clone repo
+            let cloneRepository = try repositoryManager.cloneRepository(from: baseRepository.url, at: clonedPath)
+            
+            XCTAssertTrue(FileManager.default.fileExists(atPath: url1b.path))
+            
+            // Add file 2
+            let url2 = try RepositoryHelper.addFile(repository: baseRepository, name: "file2")
+            let url2b = clonedPath.appendingPathComponent(url2.lastPathComponent)
+            
+            let commitBase = try baseRepository.head().targetCommit()
+            
+            XCTAssertTrue(FileManager.default.fileExists(atPath: url2.path))
+            XCTAssertFalse(FileManager.default.fileExists(atPath: url2b.path))
+            
+            // Fetch new branches
+            let result = try cloneRepository.remotes.get(name: "origin")
+                .pull(signature: repositoryManager.systemSignature())
+            
+            XCTAssertTrue(FileManager.default.fileExists(atPath: url1b.path))
+            XCTAssertTrue(FileManager.default.fileExists(atPath: url2b.path))
+            
+            XCTAssertTrue(result)
+            
+            let commitClone = try cloneRepository.head().targetCommit()
+            
+            XCTAssertEqual(commitBase.summary, commitClone.summary)
+            XCTAssertEqual(commitBase.oid.sha(), commitClone.oid.sha())
+            
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+}

--- a/Tests/Git2SwiftTests/RepositoryTest.swift
+++ b/Tests/Git2SwiftTests/RepositoryTest.swift
@@ -33,8 +33,7 @@ class RepositoryTest: XCTestCase {
             XCTAssertEqual("refs/heads/master", try head.targetReference().name)
             
         } catch  {
-            NSLog("\(error)")
-            XCTFail()
+            XCTFail("\(error)")
         }
     }
     
@@ -56,8 +55,7 @@ class RepositoryTest: XCTestCase {
             XCTAssert(FileManager.default.fileExists(atPath: initPath.appendingPathComponent("HEAD").path))
             
         } catch  {
-            NSLog("\(error)")
-            XCTFail()
+            XCTFail("\(error)")
         }
     }
     
@@ -83,9 +81,42 @@ class RepositoryTest: XCTestCase {
                            try repository2.head().targetCommit().oid.sha())
             
         } catch  {
-            NSLog("\(error)")
-            XCTFail()
+            XCTFail("\(error)")
         }
     }
 
+    func testCloneRepository() throws {
+        
+        do {
+            
+            let cloneUrl = URL(string: "https://github.com/damicreabox/CLibgit2.git")
+            guard cloneUrl != nil else {
+                throw GitError.notFound(ref: "URL not found :-(")
+            }
+            
+            let repositoryManager = RepositoryManager()
+            
+            // Create repository at URL
+            let clonedPath = try DirectoryManager.initDirectory(name: RepositoryTest.name + "Clone")
+            
+            // Create repo
+            let repository1 = try repositoryManager.cloneRepository(from: cloneUrl!, at: clonedPath)
+            
+            let iterator = try repository1.tags.all()
+            let tag1 = iterator.next()
+            
+            XCTAssertEqual("refs/tags/1.0.0", tag1?.name)
+            
+            let remotes = repository1.remotes
+            let remoteNames = try remotes.remoteNames()
+            XCTAssertEqual(1, remoteNames.count)
+            XCTAssertEqual("origin", remoteNames[0])
+            
+            let remote = try remotes.get(name: "origin")
+            XCTAssertEqual("origin", remote.name)
+            
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
 }

--- a/Tests/Git2SwiftTests/TagTest.swift
+++ b/Tests/Git2SwiftTests/TagTest.swift
@@ -109,6 +109,15 @@ class TagTest: XCTestCase {
             XCTAssertFalse(FileManager.default.fileExists(atPath: url2.path))
             XCTAssertFalse(FileManager.default.fileExists(atPath: url3.path))
             
+            // get tag 1
+            let getTag1 = try tags.get(name: "tag1")
+            let getTag3 = try tags.get(name: "refs/tags/tag3")
+            
+            XCTAssertEqual("refs/tags/tag1", getTag1.name)
+            XCTAssertEqual("refs/tags/tag3", getTag3.name)
+            XCTAssertEqual("tag1", getTag1.shortName)
+            XCTAssertEqual("tag3", getTag3.shortName)
+            
         } catch {
             XCTFail("\(error)")
         }

--- a/Tests/Git2SwiftTests/XCTestManifests.swift
+++ b/Tests/Git2SwiftTests/XCTestManifests.swift
@@ -86,3 +86,21 @@ extension TagTest {
     ]
     
 }
+
+extension RemoteTest {
+    
+    static var allTests = [
+        ("testRemoteRepository", testRemoteRepository),
+        ("testFetchRepository", testFetchRepository),
+        ("testPushRepository", testPushRepository)
+    ]
+    
+}
+
+extension AuthenticationTest {
+    
+    static var allTests = [
+        ("testCloneRepository", testCloneRepository)
+    ]
+    
+}

--- a/Tests/Sample.json
+++ b/Tests/Sample.json
@@ -1,0 +1,7 @@
+{
+	"authenticationTest" : true,
+	"login" : "{LOGIN}",
+	"password" : "{PASSWORD}",
+	"privateKey" : "{PRIVATE_KEY}",
+	"publicKey" : "{PUBLIC_KEY}"
+}

--- a/Xcode/Git2Swift.xcodeproj/project.pbxproj
+++ b/Xcode/Git2Swift.xcodeproj/project.pbxproj
@@ -8,48 +8,55 @@
 
 /* Begin PBXBuildFile section */
 		374763601D60BE1300A23F05 /* Git2Swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 374763561D60BE1200A23F05 /* Git2Swift.framework */; };
-		3756EA551D64E45E00CC0DC7 /* Branch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763741D60BF9700A23F05 /* Branch.swift */; };
-		3756EA561D64E45E00CC0DC7 /* Branches.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763751D60BF9700A23F05 /* Branches.swift */; };
-		3756EA571D64E45E00CC0DC7 /* BranchesIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763761D60BF9700A23F05 /* BranchesIterator.swift */; };
-		3756EA581D64E45E00CC0DC7 /* Commit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763771D60BF9700A23F05 /* Commit.swift */; };
-		3756EA591D64E45E00CC0DC7 /* ConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763781D60BF9700A23F05 /* ConfigManager.swift */; };
-		3756EA5A1D64E45E00CC0DC7 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763791D60BF9700A23F05 /* Error.swift */; };
-		3756EA5B1D64E45E00CC0DC7 /* Head+Checkout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637A1D60BF9700A23F05 /* Head+Checkout.swift */; };
-		3756EA5C1D64E45E00CC0DC7 /* Head+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637B1D60BF9700A23F05 /* Head+Merge.swift */; };
-		3756EA5D1D64E45E00CC0DC7 /* Head.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637C1D60BF9700A23F05 /* Head.swift */; };
-		3756EA5E1D64E45E00CC0DC7 /* Index+Commit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637D1D60BF9700A23F05 /* Index+Commit.swift */; };
-		3756EA5F1D64E45E00CC0DC7 /* Index+Files.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637E1D60BF9700A23F05 /* Index+Files.swift */; };
-		3756EA601D64E45E00CC0DC7 /* Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637F1D60BF9700A23F05 /* Index.swift */; };
-		3756EA611D64E45E00CC0DC7 /* Object.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763811D60BF9700A23F05 /* Object.swift */; };
-		3756EA621D64E45E00CC0DC7 /* OID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763821D60BF9700A23F05 /* OID.swift */; };
-		3756EA631D64E45E00CC0DC7 /* Reference+Target.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763831D60BF9700A23F05 /* Reference+Target.swift */; };
-		3756EA641D64E45E00CC0DC7 /* Reference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763841D60BF9700A23F05 /* Reference.swift */; };
-		3756EA651D64E45E00CC0DC7 /* Repository+Commit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763851D60BF9700A23F05 /* Repository+Commit.swift */; };
-		3756EA661D64E45E00CC0DC7 /* Repository+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763861D60BF9700A23F05 /* Repository+Lookup.swift */; };
-		3756EA671D64E45E00CC0DC7 /* Repository+Open.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763871D60BF9700A23F05 /* Repository+Open.swift */; };
-		3756EA681D64E45E00CC0DC7 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763881D60BF9700A23F05 /* Repository.swift */; };
-		3756EA691D64E45E00CC0DC7 /* RepositoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763891D60BF9700A23F05 /* RepositoryManager.swift */; };
-		3756EA6A1D64E45E00CC0DC7 /* Signature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638A1D60BF9700A23F05 /* Signature.swift */; };
-		3756EA6B1D64E45E00CC0DC7 /* Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638B1D60BF9700A23F05 /* Status.swift */; };
-		3756EA6C1D64E45E00CC0DC7 /* Statuses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638C1D60BF9700A23F05 /* Statuses.swift */; };
-		3756EA6D1D64E45E00CC0DC7 /* StatusIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638D1D60BF9700A23F05 /* StatusIterator.swift */; };
-		3756EA6E1D64E45E00CC0DC7 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638E1D60BF9700A23F05 /* Strings.swift */; };
-		3756EA6F1D64E45E00CC0DC7 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638F1D60BF9700A23F05 /* Tag.swift */; };
-		3756EA701D64E45E00CC0DC7 /* TagIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763901D60BF9700A23F05 /* TagIterator.swift */; };
-		3756EA711D64E45E00CC0DC7 /* Tags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763911D60BF9700A23F05 /* Tags.swift */; };
-		3756EA721D64E45E00CC0DC7 /* Tree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763921D60BF9700A23F05 /* Tree.swift */; };
-		3756EA731D64E47000CC0DC7 /* BranchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA311D64E3D700CC0DC7 /* BranchTest.swift */; };
-		3756EA741D64E47000CC0DC7 /* CommitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA321D64E3D700CC0DC7 /* CommitTest.swift */; };
-		3756EA751D64E47000CC0DC7 /* DirectoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA331D64E3D700CC0DC7 /* DirectoryManager.swift */; };
-		3756EA761D64E47000CC0DC7 /* HeadTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA341D64E3D700CC0DC7 /* HeadTest.swift */; };
-		3756EA771D64E47000CC0DC7 /* IndexTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA351D64E3D700CC0DC7 /* IndexTest.swift */; };
-		3756EA781D64E47000CC0DC7 /* MergeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA361D64E3D700CC0DC7 /* MergeTest.swift */; };
-		3756EA791D64E47000CC0DC7 /* OIDTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA371D64E3D700CC0DC7 /* OIDTest.swift */; };
-		3756EA7A1D64E47000CC0DC7 /* ReferenceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA381D64E3D700CC0DC7 /* ReferenceTest.swift */; };
-		3756EA7B1D64E47000CC0DC7 /* RepositoryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA391D64E3D700CC0DC7 /* RepositoryHelper.swift */; };
-		3756EA7C1D64E47000CC0DC7 /* RepositoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA3A1D64E3D700CC0DC7 /* RepositoryTest.swift */; };
-		3756EA7D1D64E47000CC0DC7 /* TagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA3B1D64E3D700CC0DC7 /* TagTest.swift */; };
-		3756EA7E1D64E47000CC0DC7 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA3C1D64E3D700CC0DC7 /* XCTestManifests.swift */; };
+		374764101D60C03C00A23F05 /* Branch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763741D60BF9700A23F05 /* Branch.swift */; };
+		374764111D60C03C00A23F05 /* Branches.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763751D60BF9700A23F05 /* Branches.swift */; };
+		374764121D60C03C00A23F05 /* BranchesIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763761D60BF9700A23F05 /* BranchesIterator.swift */; };
+		374764131D60C03C00A23F05 /* Commit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763771D60BF9700A23F05 /* Commit.swift */; };
+		374764141D60C03C00A23F05 /* ConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763781D60BF9700A23F05 /* ConfigManager.swift */; };
+		374764151D60C03C00A23F05 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763791D60BF9700A23F05 /* Error.swift */; };
+		374764161D60C03C00A23F05 /* Head+Checkout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637A1D60BF9700A23F05 /* Head+Checkout.swift */; };
+		374764171D60C03C00A23F05 /* Head+Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637B1D60BF9700A23F05 /* Head+Merge.swift */; };
+		374764181D60C03C00A23F05 /* Head.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637C1D60BF9700A23F05 /* Head.swift */; };
+		374764191D60C03C00A23F05 /* Index+Commit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637D1D60BF9700A23F05 /* Index+Commit.swift */; };
+		3747641A1D60C03C00A23F05 /* Index+Files.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637E1D60BF9700A23F05 /* Index+Files.swift */; };
+		3747641B1D60C03C00A23F05 /* Index.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747637F1D60BF9700A23F05 /* Index.swift */; };
+		3747641C1D60C03C00A23F05 /* Object.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763811D60BF9700A23F05 /* Object.swift */; };
+		3747641D1D60C03C00A23F05 /* OID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763821D60BF9700A23F05 /* OID.swift */; };
+		3747641E1D60C03C00A23F05 /* Reference+Target.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763831D60BF9700A23F05 /* Reference+Target.swift */; };
+		3747641F1D60C03C00A23F05 /* Reference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763841D60BF9700A23F05 /* Reference.swift */; };
+		374764201D60C03C00A23F05 /* Repository+Commit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763851D60BF9700A23F05 /* Repository+Commit.swift */; };
+		374764211D60C03C00A23F05 /* Repository+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763861D60BF9700A23F05 /* Repository+Lookup.swift */; };
+		374764221D60C03C00A23F05 /* Repository+Open.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763871D60BF9700A23F05 /* Repository+Open.swift */; };
+		374764231D60C03C00A23F05 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763881D60BF9700A23F05 /* Repository.swift */; };
+		374764241D60C03C00A23F05 /* RepositoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763891D60BF9700A23F05 /* RepositoryManager.swift */; };
+		374764251D60C03C00A23F05 /* Signature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638A1D60BF9700A23F05 /* Signature.swift */; };
+		374764261D60C03C00A23F05 /* Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638B1D60BF9700A23F05 /* Status.swift */; };
+		374764271D60C03C00A23F05 /* Statuses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638C1D60BF9700A23F05 /* Statuses.swift */; };
+		374764281D60C03C00A23F05 /* StatusIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638D1D60BF9700A23F05 /* StatusIterator.swift */; };
+		374764291D60C03C00A23F05 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638E1D60BF9700A23F05 /* Strings.swift */; };
+		3747642A1D60C03C00A23F05 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3747638F1D60BF9700A23F05 /* Tag.swift */; };
+		3747642B1D60C03C00A23F05 /* TagIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763901D60BF9700A23F05 /* TagIterator.swift */; };
+		3747642C1D60C03C00A23F05 /* Tags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763911D60BF9700A23F05 /* Tags.swift */; };
+		3747642D1D60C03C00A23F05 /* Tree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374763921D60BF9700A23F05 /* Tree.swift */; };
+		3756EA851D64F83D00CC0DC7 /* Remote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA831D64F83D00CC0DC7 /* Remote.swift */; };
+		3756EA861D64F83D00CC0DC7 /* Remotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA841D64F83D00CC0DC7 /* Remotes.swift */; };
+		3756EA9F1D64FC6E00CC0DC7 /* BranchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA871D64FC6600CC0DC7 /* BranchTest.swift */; };
+		3756EAA01D64FC6E00CC0DC7 /* CommitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA881D64FC6600CC0DC7 /* CommitTest.swift */; };
+		3756EAA11D64FC6E00CC0DC7 /* DirectoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA891D64FC6600CC0DC7 /* DirectoryManager.swift */; };
+		3756EAA21D64FC6E00CC0DC7 /* HeadTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA8A1D64FC6600CC0DC7 /* HeadTest.swift */; };
+		3756EAA31D64FC6E00CC0DC7 /* IndexTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA8B1D64FC6600CC0DC7 /* IndexTest.swift */; };
+		3756EAA41D64FC6E00CC0DC7 /* MergeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA8C1D64FC6600CC0DC7 /* MergeTest.swift */; };
+		3756EAA51D64FC6E00CC0DC7 /* OIDTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA8D1D64FC6600CC0DC7 /* OIDTest.swift */; };
+		3756EAA61D64FC6E00CC0DC7 /* ReferenceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA8E1D64FC6600CC0DC7 /* ReferenceTest.swift */; };
+		3756EAA71D64FC6E00CC0DC7 /* RepositoryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA8F1D64FC6600CC0DC7 /* RepositoryHelper.swift */; };
+		3756EAA81D64FC6E00CC0DC7 /* RepositoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA901D64FC6600CC0DC7 /* RepositoryTest.swift */; };
+		3756EAA91D64FC6E00CC0DC7 /* TagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA911D64FC6600CC0DC7 /* TagTest.swift */; };
+		3756EAAA1D64FC6E00CC0DC7 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EA921D64FC6600CC0DC7 /* XCTestManifests.swift */; };
+		3756EAAC1D6502B700CC0DC7 /* RemoteTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756EAAB1D6502B700CC0DC7 /* RemoteTest.swift */; };
+		379632E41D68AEA300E86F44 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 379632E31D68AEA300E86F44 /* Authentication.swift */; };
+		3797CA121D687AEC0032874D /* AuthenticationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3797CA111D687AEC0032874D /* AuthenticationTest.swift */; };
+		37A1C9501D85A351004FDBC4 /* PasswordAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A1C94F1D85A351004FDBC4 /* PasswordAuthentication.swift */; };
+		37A1C9521D85A365004FDBC4 /* KeyAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A1C9511D85A365004FDBC4 /* KeyAuthentication.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,18 +104,29 @@
 		374763911D60BF9700A23F05 /* Tags.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tags.swift; sourceTree = "<group>"; };
 		374763921D60BF9700A23F05 /* Tree.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tree.swift; sourceTree = "<group>"; };
 		374763EE1D60BFDD00A23F05 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		3756EA311D64E3D700CC0DC7 /* BranchTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BranchTest.swift; path = Git2SwiftTests/BranchTest.swift; sourceTree = "<group>"; };
-		3756EA321D64E3D700CC0DC7 /* CommitTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommitTest.swift; path = Git2SwiftTests/CommitTest.swift; sourceTree = "<group>"; };
-		3756EA331D64E3D700CC0DC7 /* DirectoryManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DirectoryManager.swift; path = Git2SwiftTests/DirectoryManager.swift; sourceTree = "<group>"; };
-		3756EA341D64E3D700CC0DC7 /* HeadTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HeadTest.swift; path = Git2SwiftTests/HeadTest.swift; sourceTree = "<group>"; };
-		3756EA351D64E3D700CC0DC7 /* IndexTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IndexTest.swift; path = Git2SwiftTests/IndexTest.swift; sourceTree = "<group>"; };
-		3756EA361D64E3D700CC0DC7 /* MergeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MergeTest.swift; path = Git2SwiftTests/MergeTest.swift; sourceTree = "<group>"; };
-		3756EA371D64E3D700CC0DC7 /* OIDTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OIDTest.swift; path = Git2SwiftTests/OIDTest.swift; sourceTree = "<group>"; };
-		3756EA381D64E3D700CC0DC7 /* ReferenceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReferenceTest.swift; path = Git2SwiftTests/ReferenceTest.swift; sourceTree = "<group>"; };
-		3756EA391D64E3D700CC0DC7 /* RepositoryHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RepositoryHelper.swift; path = Git2SwiftTests/RepositoryHelper.swift; sourceTree = "<group>"; };
-		3756EA3A1D64E3D700CC0DC7 /* RepositoryTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RepositoryTest.swift; path = Git2SwiftTests/RepositoryTest.swift; sourceTree = "<group>"; };
-		3756EA3B1D64E3D700CC0DC7 /* TagTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TagTest.swift; path = Git2SwiftTests/TagTest.swift; sourceTree = "<group>"; };
-		3756EA3C1D64E3D700CC0DC7 /* XCTestManifests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = XCTestManifests.swift; path = Git2SwiftTests/XCTestManifests.swift; sourceTree = "<group>"; };
+		3756EA831D64F83D00CC0DC7 /* Remote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Remote.swift; sourceTree = "<group>"; };
+		3756EA841D64F83D00CC0DC7 /* Remotes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Remotes.swift; sourceTree = "<group>"; };
+		3756EA871D64FC6600CC0DC7 /* BranchTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BranchTest.swift; path = Git2SwiftTests/BranchTest.swift; sourceTree = "<group>"; };
+		3756EA881D64FC6600CC0DC7 /* CommitTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CommitTest.swift; path = Git2SwiftTests/CommitTest.swift; sourceTree = "<group>"; };
+		3756EA891D64FC6600CC0DC7 /* DirectoryManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DirectoryManager.swift; path = Git2SwiftTests/DirectoryManager.swift; sourceTree = "<group>"; };
+		3756EA8A1D64FC6600CC0DC7 /* HeadTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HeadTest.swift; path = Git2SwiftTests/HeadTest.swift; sourceTree = "<group>"; };
+		3756EA8B1D64FC6600CC0DC7 /* IndexTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IndexTest.swift; path = Git2SwiftTests/IndexTest.swift; sourceTree = "<group>"; };
+		3756EA8C1D64FC6600CC0DC7 /* MergeTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MergeTest.swift; path = Git2SwiftTests/MergeTest.swift; sourceTree = "<group>"; };
+		3756EA8D1D64FC6600CC0DC7 /* OIDTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OIDTest.swift; path = Git2SwiftTests/OIDTest.swift; sourceTree = "<group>"; };
+		3756EA8E1D64FC6600CC0DC7 /* ReferenceTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReferenceTest.swift; path = Git2SwiftTests/ReferenceTest.swift; sourceTree = "<group>"; };
+		3756EA8F1D64FC6600CC0DC7 /* RepositoryHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RepositoryHelper.swift; path = Git2SwiftTests/RepositoryHelper.swift; sourceTree = "<group>"; };
+		3756EA901D64FC6600CC0DC7 /* RepositoryTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RepositoryTest.swift; path = Git2SwiftTests/RepositoryTest.swift; sourceTree = "<group>"; };
+		3756EA911D64FC6600CC0DC7 /* TagTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TagTest.swift; path = Git2SwiftTests/TagTest.swift; sourceTree = "<group>"; };
+		3756EA921D64FC6600CC0DC7 /* XCTestManifests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = XCTestManifests.swift; path = Git2SwiftTests/XCTestManifests.swift; sourceTree = "<group>"; };
+		3756EAAB1D6502B700CC0DC7 /* RemoteTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RemoteTest.swift; path = Git2SwiftTests/RemoteTest.swift; sourceTree = "<group>"; };
+		379632E31D68AEA300E86F44 /* Authentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
+		3797CA111D687AEC0032874D /* AuthenticationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AuthenticationTest.swift; path = Git2SwiftTests/AuthenticationTest.swift; sourceTree = "<group>"; };
+		37A1C9471D8571E1004FDBC4 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		37A1C9481D8571E1004FDBC4 /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Package.swift; path = ../Package.swift; sourceTree = "<group>"; };
+		37A1C9491D8571E1004FDBC4 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		37A1C94D1D8572A4004FDBC4 /* Changelog.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = Changelog.md; path = ../Changelog.md; sourceTree = "<group>"; };
+		37A1C94F1D85A351004FDBC4 /* PasswordAuthentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordAuthentication.swift; sourceTree = "<group>"; };
+		37A1C9511D85A365004FDBC4 /* KeyAuthentication.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyAuthentication.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -133,6 +151,7 @@
 		3747634C1D60BE1200A23F05 = {
 			isa = PBXGroup;
 			children = (
+				37A1C9461D8571CA004FDBC4 /* Others */,
 				374763E81D60BFDD00A23F05 /* Tests */,
 				374763731D60BF9700A23F05 /* Sources */,
 				374763571D60BE1200A23F05 /* Products */,
@@ -151,6 +170,8 @@
 		374763731D60BF9700A23F05 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				3756EA831D64F83D00CC0DC7 /* Remote.swift */,
+				3756EA841D64F83D00CC0DC7 /* Remotes.swift */,
 				374763741D60BF9700A23F05 /* Branch.swift */,
 				374763751D60BF9700A23F05 /* Branches.swift */,
 				374763761D60BF9700A23F05 /* BranchesIterator.swift */,
@@ -171,6 +192,9 @@
 				374763851D60BF9700A23F05 /* Repository+Commit.swift */,
 				374763861D60BF9700A23F05 /* Repository+Lookup.swift */,
 				374763871D60BF9700A23F05 /* Repository+Open.swift */,
+				379632E31D68AEA300E86F44 /* Authentication.swift */,
+				37A1C94F1D85A351004FDBC4 /* PasswordAuthentication.swift */,
+				37A1C9511D85A365004FDBC4 /* KeyAuthentication.swift */,
 				374763881D60BF9700A23F05 /* Repository.swift */,
 				374763891D60BF9700A23F05 /* RepositoryManager.swift */,
 				3747638A1D60BF9700A23F05 /* Signature.swift */,
@@ -190,22 +214,35 @@
 		374763E81D60BFDD00A23F05 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				3756EA311D64E3D700CC0DC7 /* BranchTest.swift */,
-				3756EA321D64E3D700CC0DC7 /* CommitTest.swift */,
-				3756EA331D64E3D700CC0DC7 /* DirectoryManager.swift */,
-				3756EA341D64E3D700CC0DC7 /* HeadTest.swift */,
-				3756EA351D64E3D700CC0DC7 /* IndexTest.swift */,
-				3756EA361D64E3D700CC0DC7 /* MergeTest.swift */,
-				3756EA371D64E3D700CC0DC7 /* OIDTest.swift */,
-				3756EA381D64E3D700CC0DC7 /* ReferenceTest.swift */,
-				3756EA391D64E3D700CC0DC7 /* RepositoryHelper.swift */,
-				3756EA3A1D64E3D700CC0DC7 /* RepositoryTest.swift */,
-				3756EA3B1D64E3D700CC0DC7 /* TagTest.swift */,
-				3756EA3C1D64E3D700CC0DC7 /* XCTestManifests.swift */,
+				3756EA871D64FC6600CC0DC7 /* BranchTest.swift */,
+				3756EA881D64FC6600CC0DC7 /* CommitTest.swift */,
+				3756EA891D64FC6600CC0DC7 /* DirectoryManager.swift */,
+				3756EA8A1D64FC6600CC0DC7 /* HeadTest.swift */,
+				3756EA8B1D64FC6600CC0DC7 /* IndexTest.swift */,
+				3756EA8C1D64FC6600CC0DC7 /* MergeTest.swift */,
+				3756EAAB1D6502B700CC0DC7 /* RemoteTest.swift */,
+				3756EA8D1D64FC6600CC0DC7 /* OIDTest.swift */,
+				3756EA8E1D64FC6600CC0DC7 /* ReferenceTest.swift */,
+				3756EA8F1D64FC6600CC0DC7 /* RepositoryHelper.swift */,
+				3756EA901D64FC6600CC0DC7 /* RepositoryTest.swift */,
+				3797CA111D687AEC0032874D /* AuthenticationTest.swift */,
+				3756EA911D64FC6600CC0DC7 /* TagTest.swift */,
+				3756EA921D64FC6600CC0DC7 /* XCTestManifests.swift */,
 				374763EE1D60BFDD00A23F05 /* Info.plist */,
 			);
 			name = Tests;
 			path = ../Tests;
+			sourceTree = "<group>";
+		};
+		37A1C9461D8571CA004FDBC4 /* Others */ = {
+			isa = PBXGroup;
+			children = (
+				37A1C94D1D8572A4004FDBC4 /* Changelog.md */,
+				37A1C9471D8571E1004FDBC4 /* LICENSE */,
+				37A1C9481D8571E1004FDBC4 /* Package.swift */,
+				37A1C9491D8571E1004FDBC4 /* README.md */,
+			);
+			name = Others;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -318,36 +355,41 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3756EA551D64E45E00CC0DC7 /* Branch.swift in Sources */,
-				3756EA561D64E45E00CC0DC7 /* Branches.swift in Sources */,
-				3756EA571D64E45E00CC0DC7 /* BranchesIterator.swift in Sources */,
-				3756EA581D64E45E00CC0DC7 /* Commit.swift in Sources */,
-				3756EA591D64E45E00CC0DC7 /* ConfigManager.swift in Sources */,
-				3756EA5A1D64E45E00CC0DC7 /* Error.swift in Sources */,
-				3756EA5B1D64E45E00CC0DC7 /* Head+Checkout.swift in Sources */,
-				3756EA5C1D64E45E00CC0DC7 /* Head+Merge.swift in Sources */,
-				3756EA5D1D64E45E00CC0DC7 /* Head.swift in Sources */,
-				3756EA5E1D64E45E00CC0DC7 /* Index+Commit.swift in Sources */,
-				3756EA5F1D64E45E00CC0DC7 /* Index+Files.swift in Sources */,
-				3756EA601D64E45E00CC0DC7 /* Index.swift in Sources */,
-				3756EA611D64E45E00CC0DC7 /* Object.swift in Sources */,
-				3756EA621D64E45E00CC0DC7 /* OID.swift in Sources */,
-				3756EA631D64E45E00CC0DC7 /* Reference+Target.swift in Sources */,
-				3756EA641D64E45E00CC0DC7 /* Reference.swift in Sources */,
-				3756EA651D64E45E00CC0DC7 /* Repository+Commit.swift in Sources */,
-				3756EA661D64E45E00CC0DC7 /* Repository+Lookup.swift in Sources */,
-				3756EA671D64E45E00CC0DC7 /* Repository+Open.swift in Sources */,
-				3756EA681D64E45E00CC0DC7 /* Repository.swift in Sources */,
-				3756EA691D64E45E00CC0DC7 /* RepositoryManager.swift in Sources */,
-				3756EA6A1D64E45E00CC0DC7 /* Signature.swift in Sources */,
-				3756EA6B1D64E45E00CC0DC7 /* Status.swift in Sources */,
-				3756EA6C1D64E45E00CC0DC7 /* Statuses.swift in Sources */,
-				3756EA6D1D64E45E00CC0DC7 /* StatusIterator.swift in Sources */,
-				3756EA6E1D64E45E00CC0DC7 /* Strings.swift in Sources */,
-				3756EA6F1D64E45E00CC0DC7 /* Tag.swift in Sources */,
-				3756EA701D64E45E00CC0DC7 /* TagIterator.swift in Sources */,
-				3756EA711D64E45E00CC0DC7 /* Tags.swift in Sources */,
-				3756EA721D64E45E00CC0DC7 /* Tree.swift in Sources */,
+				374764101D60C03C00A23F05 /* Branch.swift in Sources */,
+				374764111D60C03C00A23F05 /* Branches.swift in Sources */,
+				374764121D60C03C00A23F05 /* BranchesIterator.swift in Sources */,
+				374764131D60C03C00A23F05 /* Commit.swift in Sources */,
+				374764141D60C03C00A23F05 /* ConfigManager.swift in Sources */,
+				374764151D60C03C00A23F05 /* Error.swift in Sources */,
+				374764161D60C03C00A23F05 /* Head+Checkout.swift in Sources */,
+				3756EA861D64F83D00CC0DC7 /* Remotes.swift in Sources */,
+				374764171D60C03C00A23F05 /* Head+Merge.swift in Sources */,
+				374764181D60C03C00A23F05 /* Head.swift in Sources */,
+				374764191D60C03C00A23F05 /* Index+Commit.swift in Sources */,
+				3747641A1D60C03C00A23F05 /* Index+Files.swift in Sources */,
+				3747641B1D60C03C00A23F05 /* Index.swift in Sources */,
+				3747641C1D60C03C00A23F05 /* Object.swift in Sources */,
+				3747641D1D60C03C00A23F05 /* OID.swift in Sources */,
+				3747641E1D60C03C00A23F05 /* Reference+Target.swift in Sources */,
+				3747641F1D60C03C00A23F05 /* Reference.swift in Sources */,
+				374764201D60C03C00A23F05 /* Repository+Commit.swift in Sources */,
+				374764211D60C03C00A23F05 /* Repository+Lookup.swift in Sources */,
+				374764221D60C03C00A23F05 /* Repository+Open.swift in Sources */,
+				37A1C9501D85A351004FDBC4 /* PasswordAuthentication.swift in Sources */,
+				374764231D60C03C00A23F05 /* Repository.swift in Sources */,
+				374764241D60C03C00A23F05 /* RepositoryManager.swift in Sources */,
+				374764251D60C03C00A23F05 /* Signature.swift in Sources */,
+				374764261D60C03C00A23F05 /* Status.swift in Sources */,
+				374764271D60C03C00A23F05 /* Statuses.swift in Sources */,
+				374764281D60C03C00A23F05 /* StatusIterator.swift in Sources */,
+				374764291D60C03C00A23F05 /* Strings.swift in Sources */,
+				3747642A1D60C03C00A23F05 /* Tag.swift in Sources */,
+				3747642B1D60C03C00A23F05 /* TagIterator.swift in Sources */,
+				3756EA851D64F83D00CC0DC7 /* Remote.swift in Sources */,
+				3747642C1D60C03C00A23F05 /* Tags.swift in Sources */,
+				3747642D1D60C03C00A23F05 /* Tree.swift in Sources */,
+				37A1C9521D85A365004FDBC4 /* KeyAuthentication.swift in Sources */,
+				379632E41D68AEA300E86F44 /* Authentication.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -355,18 +397,20 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3756EA731D64E47000CC0DC7 /* BranchTest.swift in Sources */,
-				3756EA741D64E47000CC0DC7 /* CommitTest.swift in Sources */,
-				3756EA751D64E47000CC0DC7 /* DirectoryManager.swift in Sources */,
-				3756EA761D64E47000CC0DC7 /* HeadTest.swift in Sources */,
-				3756EA771D64E47000CC0DC7 /* IndexTest.swift in Sources */,
-				3756EA781D64E47000CC0DC7 /* MergeTest.swift in Sources */,
-				3756EA791D64E47000CC0DC7 /* OIDTest.swift in Sources */,
-				3756EA7A1D64E47000CC0DC7 /* ReferenceTest.swift in Sources */,
-				3756EA7B1D64E47000CC0DC7 /* RepositoryHelper.swift in Sources */,
-				3756EA7C1D64E47000CC0DC7 /* RepositoryTest.swift in Sources */,
-				3756EA7D1D64E47000CC0DC7 /* TagTest.swift in Sources */,
-				3756EA7E1D64E47000CC0DC7 /* XCTestManifests.swift in Sources */,
+				3756EAA71D64FC6E00CC0DC7 /* RepositoryHelper.swift in Sources */,
+				3756EAA11D64FC6E00CC0DC7 /* DirectoryManager.swift in Sources */,
+				3756EAA01D64FC6E00CC0DC7 /* CommitTest.swift in Sources */,
+				3756EAA81D64FC6E00CC0DC7 /* RepositoryTest.swift in Sources */,
+				3756EA9F1D64FC6E00CC0DC7 /* BranchTest.swift in Sources */,
+				3756EAAC1D6502B700CC0DC7 /* RemoteTest.swift in Sources */,
+				3756EAAA1D64FC6E00CC0DC7 /* XCTestManifests.swift in Sources */,
+				3756EAA31D64FC6E00CC0DC7 /* IndexTest.swift in Sources */,
+				3756EAA41D64FC6E00CC0DC7 /* MergeTest.swift in Sources */,
+				3756EAA61D64FC6E00CC0DC7 /* ReferenceTest.swift in Sources */,
+				3756EAA51D64FC6E00CC0DC7 /* OIDTest.swift in Sources */,
+				3797CA121D687AEC0032874D /* AuthenticationTest.swift in Sources */,
+				3756EAA21D64FC6E00CC0DC7 /* HeadTest.swift in Sources */,
+				3756EAA91D64FC6E00CC0DC7 /* TagTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
- Update project to match swift package manager.
  - Add module map Xcode.
  - Use CLibgit2 module instead of bridging
  - Register tests cases
- Update to Xcode 8 beta 6
  - Add Tests suffix to testing target
- Add clone repositoy with test on github.
- Create remotes
  - Create remote
  - Delete remote
  - List remote names
  - Fetch from
  - Push to remote
  - Pull from remote
- Add authentication
  - Password
  - SSH key
